### PR TITLE
0.4.8 -- include a 'check_return=' kwarg for 'run_command()'

### DIFF
--- a/chromogenic/drivers/openstack.py
+++ b/chromogenic/drivers/openstack.py
@@ -582,6 +582,8 @@ class ImageManager(BaseDriver):
             raise Exception("Server %s does not exist" % instance_id)
         logger.debug("Instance is prepared to create a snapshot")
         snapshot_id = self.nova.servers.create_image(server, name, metadata)
+        if getattr(self,'hook') and hasattr(self.hook, 'on_update_status'):
+            self.hook.on_update_status("Retrieving Snapshot:%s created from Instance:%s" % (snapshot_id, instance_id))
         snapshot = self.get_image(snapshot_id)
         if not delay:
             return snapshot

--- a/chromogenic/version.py
+++ b/chromogenic/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 4, 7, 'dev', 0)
+VERSION = (0, 4, 8, 'dev', 0)
 
 git_match = "(?P<git_flag>git://)\S*#egg="\
             "(?P<egg>[a-zA-Z0-9-]*[a-zA-Z])"\


### PR DESCRIPTION
And fail when `check_return=True` and a non-zero exit code received.

Set the `umount` calls of `remove_chroot_env` to ensure that they are indeed removed prior to moving on to the rest of the calls (like `remove_vm_specific_data`)...