### PR TITLE
Problem: correct path and type in clean.py

### DIFF
--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -72,7 +72,7 @@ def remove_atmo_data(mounted_path, dry_run=False):
                     'usr/sbin/atmo_boot.py',
                     'var/log/atmo/post-scripts/*',
                     'var/log/atmo/*.log',
-                    '/opt/cyverse/tmp',
+                    'opt/cyverse/tmp',
                     #Puppet
                     'var/lib/puppet/run/*.pid',
                     'etc/puppet/ssl', 

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -84,7 +84,7 @@ def remove_atmo_data(mounted_path, dry_run=False):
     replace_line_files = [
         #('replace_pattern','replace_with','in_file'),
         (".*vncserver$", "", "etc/rc.local"),
-        (".*shellinbaox.*", "", "etc/rc.local")
+        (".*shellinabox.*", "", "etc/rc.local")
     ]
     multiline_delete_files = [
         #TEMPLATE:


### PR DESCRIPTION
## Description 

To make the addition of _cleaning_ for `opt/cyverse/tmp`, the leading slash is removed. 

This was not causing problems because a "fail safe" later in the cleanup code was preventing this. 

This also corrects a type for coding handling "shellinabox". 

🗒 For a historic note, "shellinabox" was used prior to the adoption of GateOne (and now Apache Guacamole) for remote SSH shell access to instances (VMs) within the cloud. 