### PR TITLE
Problem: Libraries should not pin dependencies

### DIFF
--- a/chromogenic/version.py
+++ b/chromogenic/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 4, 17, 'dev', 0)
+VERSION = (0, 5, 0, 'dev', 1)
 
 git_match = "(?P<git_flag>git://)\S*#egg="\
             "(?P<egg>[a-zA-Z0-9-]*[a-zA-Z])"\
@@ -15,60 +15,7 @@ egg_match = "(?P<egg>\S.*[a-zA-Z])"\
             "(?P<opt_version_flag>[-=]+)?"\
             "(?P<opt_version>[0-9]*[0-9.-]*[0-9])?(?P<dev_flag>-dev)?"
             # Version is optional
-def read_requirements(requirements_file):
-    """
-    Requirements files use two specific formats:
-    packagename==1.3.1
-    and
-    git+git://github.com/abc/xyz.git#egg=packagename-1.3.1
 
-    This function converts git to the bottom format
-    and
-    includes them as a dependency_link for setup.py
-    """
-    import re
-    dependencies = []
-    install_requires = []
-    egg_regex = re.compile(egg_match)
-    git_regex = re.compile(git_match)
-    with open(requirements_file, 'r') as f:
-        for line in f.read().split('\n'):
-            # Skip empty spaces
-            if not line:
-                continue
-            # Ignore comments.
-            if line.lstrip().startswith("#"):
-                continue
-            # Read the line for version info
-            r = git_regex.search(line)
-            if not r:
-                r = egg_regex.search(line)
-            if not r:
-                continue
-            group = r.groupdict()
-            if not group:
-                continue
-            #Dependencies will match git_flag
-            if group.get('git_flag'):
-                dependencies.append(line)
-            #Requirements should be added for each line
-            if group.get('opt_version') and group.get('egg'):
-                install_requires.append("%s==%s%s" % (group['egg'], group['opt_version'],
-                        '-dev' if group.get('dev_flag') else ''))
-            elif group.get('egg'):
-                install_requires.append("%s" % (group['egg']))
-    return (dependencies, install_requires)
-
-
-def write_requirements(requirements_file, new_file):
-    (dependencies, install_requires) = read_requirements(requirements_file)
-    with open(new_file,'w') as write_to:
-        write_to.write("#Dependencies:\n")
-        [write_to.write("%s\n" % line) for line in dependencies]
-        write_to.write("#Requirements:\n")
-        [write_to.write("%s\n" % line) for line in install_requires]
-    return
-        
 
 def git_sha():
     loc = abspath(dirname(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,3 @@
-threepio==0.2.0
-rtwo>=0.5.2
-boto==2.39.0
+--index-url https://pypi.python.org/simple/
 
-# rtwo will supply these requirements, which will likely be newer.
-# python-glanceclient==1.2.0
-# python-keystoneclient==2.1.1
-# python-novaclient==3.2.0
-
-# Optional for old eucalyptus support.
-# git+git://github.com/iPlantCollaborativeOpenSource/euca2ools.git#egg=euca2ools-1.3.3
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,29 @@
 import setuptools
-from chromogenic.version import get_version, read_requirements
+from chromogenic.version import get_version
 
 readme = open('README.md').read()
-dependencies, requirements = read_requirements('requirements.txt')
 
 long_description = readme
 
 setuptools.setup(
     name='chromogenic',
     version=get_version('short'),
-    author='iPlant Collaborative',
-    author_email='atmodevs@gmail.com',
+    author='CyVerse',
+    author_email='atmo-dev@cyverse.org',
     description="A unified imaging interface supporting multiple cloud providers.",
     long_description=long_description,
     license="Apache License, Version 2.0",
-    url="https://github.com/iPlantCollaborativeOpenSource/chromogenic",
+    url="https://github.com/cyverse/chromogenic",
     packages=setuptools.find_packages(),
-    dependency_links=dependencies,
-    install_requires=requirements,
+    dependency_links=[],
+    install_requires=[
+        "threepio",
+        "rtwo",
+        "boto",
+        "python-glanceclient",
+        "python-keystoneclient",
+        "python-novaclient"
+    ],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Solution: Specify 'abstract' dependencies without concrete versions.

Also moved the now unpinned dependencies directly into `setup.py`
instead of loading them from the `requirement.txt` file.

During development we still need a `requirements.txt` file. For _DRY_
sake the `requirements.txt` file now installs dependencies by pointing
at the `setup.py` using `-e .`.

In implementing the above I followed the advice in this blog post:
https://caremad.io/posts/2013/07/setup-vs-requirement/

If for some reason we need to limit versions of packages at the
application level then we can use a constraints file:

https://stackoverflow.com/questions/34645821/pip-constraints-files