### PR TITLE
Fix cache issue causing imaging to fail

### DIFF
--- a/chromogenic/drivers/openstack.py
+++ b/chromogenic/drivers/openstack.py
@@ -628,6 +628,9 @@ class ImageManager(BaseDriver):
             raise Exception("Server %s does not exist" % instance_id)
         logger.debug("Instance is prepared to create a snapshot")
         snapshot_id = self.nova.servers.create_image(server, name, metadata)
+
+        # Evict the image cache, since we have created a new image
+        self.clear_cache()
         if hasattr(self,'hook') and hasattr(self.hook, 'on_update_status'):
             self.hook.on_update_status("Retrieving Snapshot:%s created from Instance:%s" % (snapshot_id, instance_id))
         snapshot = self.get_image(snapshot_id)

--- a/chromogenic/version.py
+++ b/chromogenic/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 4, 17, 'dev', 0)
+VERSION = (0, 4, 18, 'dev', 0)
 
 git_match = "(?P<git_flag>git://)\S*#egg="\
             "(?P<egg>[a-zA-Z0-9-]*[a-zA-Z])"\


### PR DESCRIPTION
## Description
### Problem
UnboundLocalError: local variable properties referenced before assignment

### Solution
Fix the underlying issue, that the parent image was None

### Explanation
When an instance is imaged, a snapshot is made of the instance, then that snapshot is mounted locally so that the filesystem can be cleaned. Then that cleaned image is then uploaded as the image, which will appear in atmosphere.

When chromogenic images, it actually checks if a snapshot has been made before and just uses that rather than always creating a snapshot.

Just prior to uploading, chromogenic looks up the snapshot image (what it calls the parent image), and uses properties on it for the final image. The bug was that looking up the snapshot would return None sometimes, which would cause the properties lookup to fail.

Chromogenic would first populate the cache, when it checked if the snapshot had ever been created. Then it would create the snapshot (never updating the cache) then would later ask if the cache had the snapshot.

So the error can be reliably reproduced, if you delete the snapshot before you retry imaging.