### PR TITLE
Problem: Imaging broken on 4.4.0 kernels

### DIFF
--- a/chromogenic/common.py
+++ b/chromogenic/common.py
@@ -664,6 +664,7 @@ def fsck_qcow(image_path):
     nbd_dev = _get_next_nbd()
     try:
         run_command(['qemu-nbd', '-c', nbd_dev, image_path])
+        run_command(['partprobe', '-s', nbd_dev])
         run_command(['fsck', '-y', nbd_dev])
     finally:
         run_command(['qemu-nbd', '-d', nbd_dev])
@@ -699,6 +700,7 @@ def mount_qcow(image_path, mount_point):
     nbd_dev = _get_next_nbd()
     #Mount disk to /dev/nbd*
     run_command(['qemu-nbd', '-c', nbd_dev, image_path])
+    run_command(['partprobe', '-s', nbd_dev])
     #Check if filesystem has multiple partitions
     try:
         partition = _fdisk_get_partition(nbd_dev)


### PR DESCRIPTION
Symptom: Imaging fails with the following in the logs:

```
Completed Command with exit code 0: qemu-nbd -c /dev/nbd1 /Storage/johndoe/Ubuntu 18.04 Devel and Docker.qcow2
Completed Command with exit code 0: fdisk -l /dev/nbd1
Completed Command with exit code 1: parted -sm /dev/nbd1p1 print
Completed Command with exit code 1: parted -sm /dev/nbd1p1 print
Received 'parted output' of Error: Could not stat device /dev/nbd1p1 - No such file or directory.
```

This is a known issue:

- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1743026
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829532

Solution:

The workaround is to call `partprobe` on the nbd<*> device, and was suggested by @jmlowe.

Try the following commands on a system with 3.13.0 kernel and a system with a 4.4.0 kernel:

```bash
qemu-nbd -c /dev/nbd1 /Storage/johndoe/Ubuntu\ 18.04\ Devel\ and\ Docker.qcow2
ls /dev/nbd1p1
```

On a 3.13.0 system you'll see something like:

```
/dev/nbd1p1
```

But on a 4.4.0 system you'll see something like:

```
ls: cannot access /dev/nbd1p1: No such file or directory
```

But if you then run the following commands on the 4.4.0 system:

```bash
partprobe -s /dev/nbd1
ls /dev/nbd1p1
```

Then you'll get:

```bash
/dev/nbd1: gpt partitions 14 15 1
/dev/nbd1p1
```