### PR TITLE
Get just intended server, not all servers on provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.4.19...HEAD) - YYYY-MM-DD
+### Fixed
+  - Fix unnecessary expensive Nova API call when only one server is needed
+    ([#11](https://github.com/cyverse/chromogenic/pull/11))
 ## [0.4.19](https://github.com/cyverse/chromogenic/compare/0.4.18...0.4.19) - 2018-08-31
 ### Added
   - Added PR template, change log, and travis to automatically push new pypi

--- a/chromogenic/drivers/openstack.py
+++ b/chromogenic/drivers/openstack.py
@@ -784,12 +784,7 @@ class ImageManager(BaseDriver):
         return None
 
     def get_server(self, server_id):
-        servers = [server for server in
-                self.nova.servers.list(search_opts={'all_tenants':1}) if
-                server.id == server_id]
-        if not servers:
-            return None
-        return servers[0]
+        return self.nova.servers.get(server_id)
 
     def list_nova_images(self):
         return self.nova.images.list()


### PR DESCRIPTION
## Description

Problem: Unnecessary expensive Nova API call to get all servers times out in production
Solution: Get only the needed server

## Checklist before merging Pull Requests
- [ ] ~New test(s) included to reproduce the bug/verify the feature~
- [x] Add an entry in the changelog
- [ ] ~Documentation created/updated (include links)~
- [ ] ~If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`~
- [ ] Reviewed and approved by at least one other contributor.