### PR TITLE
Clear cache of Glance images before getting metadata of parent image

### DIFF
--- a/chromogenic/drivers/openstack.py
+++ b/chromogenic/drivers/openstack.py
@@ -261,6 +261,7 @@ class ImageManager(BaseDriver):
             if download_dir:
                 download_location = download_dir/username/image_name.qcow2
 	"""
+        self.clear_cache()
         parent_image = self.get_image(parent_image_id)
         #Step 1 download a local copy
         if not os.path.exists(download_location) or kwargs.get('force',False):


### PR DESCRIPTION
## Description

Problem: Chromogenic was creating new images with `None` disk_format and container_format, which causes Glance to crash when uploading data to new image

Solution: Ensure we get latest metadata for the parent snapshot of a new image, hoping that correct disk_format and container_format will be populated

For context, go [here](https://cyverse.slack.com/archives/G081H13H7/p1542242278048000) and scroll up.

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [ ] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.