### PR TITLE
ATMO-2160: Use virt-sysprep instead of mounting image and running commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.4.20...HEAD) - YYYY-MM-DD
+  - Replace chroot and mount with virt-sysprep for preparing and cleaning images
+    ([#14](https://github.com/cyverse/chromogenic/pull/14))
+
 ## [0.4.20](https://github.com/cyverse/chromogenic/compare/0.4.19...0.4.20) - 2018-09-14
 ### Fixed
   - Fix unnecessary expensive Nova API call when only one server is needed

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -16,246 +16,10 @@ import chromogenic.virt_sysprep as virt_sysprep_files
 
 logger = logging.getLogger(__name__)
 
-def remove_user_data(mounted_path, author=None, dry_run=False):
-    """
-    Remove user data from an image that has already been mounted
-    NOTE: This will also include removing *CLOUD* user data.
-    """
-    if not check_mounted(mounted_path):
-        raise Exception("Expected a mounted path at %s" % mounted_path)
-    distro = check_distro(mounted_path)
-    if 'ubuntu' in distro:
-        cloud_user = 'ubuntu'
-        remove_user_cmd = '/usr/sbin/userdel'
-    elif 'centos' in distro:
-        cloud_user = 'centos'
-        remove_user_cmd = '/usr/sbin/userdel'
-    else:
-        cloud_user = ''
-        remove_user_cmd = ''
-        raise Exception("Encountered unknown distro %s -- Cannot guarantee removal of the cloud-user" % distro)
-
-    remove_files = ['home/*', ]
-    overwrite_files = []
-    remove_line_files = []
-    replace_line_files = [
-        #('replace_pattern','replace_with','in_file'),
-        ("users:x:100:.*", "users:x:100:", "etc/group"),
-        #TODO: Check this should not be 'AllowGroups users core-services root'
-        ("AllowGroups users root.*", "", "etc/ssh/sshd_config"),
-    ]
-    execute_lines = []
-    if remove_user_cmd and cloud_user:
-        execute_lines.append([remove_user_cmd, '-r', cloud_user])
-    if remove_user_cmd and author:
-        execute_lines.append([remove_user_cmd, '-r', author])
-
-    multiline_delete_files = [
-        #('delete_from', 'delete_to', 'replace_where')
-    ]
-    _perform_cleaning(mounted_path, rm_files=remove_files,
-                      remove_line_files=remove_line_files,
-                      overwrite_list=overwrite_files,
-                      replace_line_files=replace_line_files,
-                      multiline_delete_files=multiline_delete_files,
-                      execute_lines=execute_lines,
-                      dry_run=dry_run)
-
-
-def remove_atmo_data(mounted_path, dry_run=False):
-    """
-    Remove atmosphere data from an image that has already been mounted
-    """
-    if not check_mounted(mounted_path):
-        raise Exception("Expected a mounted path at %s" % mounted_path)
-    remove_files = [#Atmo
-                    'etc/rc.local.atmo',
-                    'usr/sbin/atmo_boot.py',
-                    'var/log/atmo/post-scripts/*',
-                    'var/log/atmo/*.log',
-                    '/opt/cyverse/tmp',
-                    #Puppet
-                    'var/lib/puppet/run/*.pid',
-                    'etc/puppet/ssl',
-                    #SSH
-                    'root/.ssh',
-                   ]
-    overwrite_files = []
-    remove_line_files = []
-    replace_line_files = [
-        #('replace_pattern','replace_with','in_file'),
-        (".*vncserver$", "", "etc/rc.local"),
-        (".*shellinbaox.*", "", "etc/rc.local")
-    ]
-    multiline_delete_files = [
-        #TEMPLATE:
-        #('delete_from', 'delete_to', 'replace_where')
-
-        #SUDOERS:
-        ("## Atmosphere System", "## End Atmosphere System", "etc/sudoers"),
-        ("# Begin Nagios", "# End Nagios", "etc/sudoers"),
-        ("# Begin Sensu", "# End Sensu", "etc/sudoers"),
-        ("## Atmosphere System", "", "etc/sudoers"), #Delete to end-of-file..
-        ("#includedir \/etc\/sudoers.d", "", "etc/sudoers"), #Delete to end-of-file..
-        #SSHD_CONFIG:
-        ("## Atmosphere System", "## End Atmosphere System",
-         "etc/ssh/sshd_config"),
-        ("## Atmosphere System", "", "etc/ssh/sshd_config"), #Delete to end-of-file..
-        #.BASHRC:
-        ("## Atmosphere System", "## End Atmosphere System",
-         "etc/skel/.bashrc"),
-    ]
-    append_line_files = [
-        #('append_line','in_file'),
-        ("#includedir /etc/sudoers.d", "etc/sudoers"),
-    ]
-    _perform_cleaning(mounted_path, rm_files=remove_files,
-                      remove_line_files=remove_line_files,
-                      overwrite_list=overwrite_files,
-                      replace_line_files=replace_line_files,
-                      multiline_delete_files=multiline_delete_files,
-                      append_line_files=append_line_files,
-                      dry_run=dry_run)
-
-
-def remove_vm_specific_data(mounted_path, dry_run=False):
-    """
-    Remove "VM specific data" from an image that has already been mounted
-    this data should include:
-    * Logs
-    * Pids
-    * dev, proc, ...
-    """
-    if not check_mounted(mounted_path):
-        raise Exception("Expected a mounted path at %s" % mounted_path)
-    remove_files = [
-      'mnt/*', 'mnt/.*',
-      'tmp/*', 'tmp/.*',
-      'proc/*', 'proc/.*',
-      'root/*', 'root/.*',
-      # 'dev/*', 'dev/.*'
-    ]
-    remove_line_files = [
-        #("pattern_match", "file_to_test")
-        # Save /dev/sda1, /dev/vda, /dev/xvda
-        # Delete all other partitions in etc/fstab
-        ("sda[2-9]", "etc/fstab"),
-        ("sda1[0-9]", "etc/fstab"),
-        ("vd[b-z]",  "etc/fstab"),
-    ]
-    overwrite_files = [
-        'etc/udev/rules.d/70-persistent-net.rules',
-        'lib/udev/rules.d/75-persistent-net-generator.rules',
-        'root/.bash_history', 'var/log/*',
-    ]
-    replace_line_files = [
-        #('replace_pattern','replace_with','in_file'),
-        ("HWADDR=*", "", "etc/sysconfig/network-scripts/ifcfg-eth0"),
-        ("MACADDR=*", "", "etc/sysconfig/network-scripts/ifcfg-eth0"),
-        ("SELINUX=.*", "SELINUX=disabled", "etc/syslinux/selinux"),
-        ("SELINUX=.*", "SELINUX=disabled", "etc/selinux/config"),
-        ("users:", "#users:", "etc/cloud/cloud.cfg"),
-        ("[ ]* - default", "#  - default", "etc/cloud/cloud.cfg"),
-        ("disable_root: true", "disable_root: false", "etc/cloud/cloud.cfg"),
-        ("disable_root: 1", "disable_root: 0", "etc/cloud/cloud.cfg"),
-        ("ssh_deletekeys:.*1", "ssh_deletekeys: 0", "etc/cloud/cloud.cfg"),
-        ("ssh_deletekeys:.*true", "ssh_deletekeys: false", "etc/cloud/cloud.cfg"),
-    ]
-    multiline_delete_files = [
-        #('delete_from', 'delete_to', 'replace_where')
-    ]
-    apt_uninstall(mounted_path, ['avahi-daemon', ])
-    package_uninstall(mounted_path, ['fail2ban', ])
-    package_install(mounted_path, ['cloud-init', 'cloud-utils'])
-    _perform_cleaning(mounted_path, rm_files=remove_files,
-                      remove_line_files=remove_line_files,
-                      overwrite_list=overwrite_files,
-                      replace_line_files=replace_line_files,
-                      multiline_delete_files=multiline_delete_files,
-                      dry_run=dry_run)
-
-
-def _perform_cleaning(mounted_path, rm_files=None,
-                      remove_line_files=None, overwrite_list=None,
-                      replace_line_files=None, multiline_delete_files=None,
-                      append_line_files=None, execute_lines=None, dry_run=False):
-    """
-    Runs the commands to perform all cleaning operations.
-    For more information see the specific function
-    """
-    remove_files(rm_files, mounted_path, dry_run)
-    overwrite_files(overwrite_list, mounted_path, dry_run)
-    remove_line_in_files(remove_line_files, mounted_path, dry_run)
-    replace_line_in_files(replace_line_files, mounted_path, dry_run)
-    remove_multiline_in_files(multiline_delete_files, mounted_path, dry_run)
-    append_line_in_files(append_line_files, mounted_path, dry_run)
-    execute_chroot_commands(execute_lines, mounted_path, dry_run)
 
 # Commands requiring a 'chroot'
 
-
-def package_uninstall(mounted_path, package_list):
-    distro = check_distro(mounted_path)
-    if 'centos' in distro.lower():
-        return yum_uninstall(mounted_path, package_list)
-    elif 'ubuntu' in distro.lower():
-        return apt_uninstall(mounted_path, package_list)
-
-
-def package_install(mounted_path, package_list):
-    distro = check_distro(mounted_path)
-    if 'centos' in distro.lower():
-        return yum_install(mounted_path, package_list)
-    elif 'ubuntu' in distro.lower():
-        return apt_install(mounted_path, package_list)
-
-
-def yum_install(mounted_path, install_list):
-    distro = check_distro(mounted_path)
-    try:
-        prepare_chroot_env(mounted_path)
-        for install_item in install_list:
-            run_command(["/usr/sbin/chroot", mounted_path,
-                         'yum', '-qy', 'install', install_item])
-    finally:
-        remove_chroot_env(mounted_path)
-
-def apt_install(mounted_path, install_list):
-    distro = check_distro(mounted_path)
-    try:
-        prepare_chroot_env(mounted_path)
-        for install_item in install_list:
-            run_command(["/usr/sbin/chroot", mounted_path,
-                         'apt-get', '-qy', 'install', install_item])
-    finally:
-        remove_chroot_env(mounted_path)
-
-
-
-def yum_uninstall(mounted_path, uninstall_list):
-    distro = check_distro(mounted_path)
-    if 'centos' not in distro.lower():
-        return
-    try:
-        prepare_chroot_env(mounted_path)
-        for uninstall_item in uninstall_list:
-            run_command(["/usr/sbin/chroot", mounted_path,
-                         'yum', '-qy', 'remove', uninstall_item])
-    finally:
-        remove_chroot_env(mounted_path)
-
-def apt_uninstall(mounted_path, uninstall_list):
-    distro = check_distro(mounted_path)
-    if 'ubuntu' not in distro.lower():
-        return
-    try:
-        prepare_chroot_env(mounted_path)
-        for uninstall_item in uninstall_list:
-            run_command(["/usr/sbin/chroot", mounted_path,
-                         'apt-get', '-qy', 'purge', uninstall_item])
-    finally:
-        remove_chroot_env(mounted_path)
-
+# still used in drivers/virtualbox.py
 def remove_ldap(mounted_path):
     try:
         prepare_chroot_env(mounted_path)
@@ -264,6 +28,7 @@ def remove_ldap(mounted_path):
     finally:
         remove_chroot_env(mounted_path)
 
+# still used in drivers/virtualbox.py
 def reset_root_password(mounted_path, new_password='atmosphere'):
     try:
         prepare_chroot_env(mounted_path)
@@ -272,46 +37,16 @@ def reset_root_password(mounted_path, new_password='atmosphere'):
     finally:
         remove_chroot_env(mounted_path)
 
-def file_hook_cleaning(mounted_path, **kwargs):
-    """
-    Look for a 'file_hook' on the actual filesystem (Mounted at
-    mounted_path)
 
-    If it exists, prepare a chroot and execute the file
-    """
-    #File hooks inside the local image
-    clean_filename = kwargs.get('file_hook',"/etc/chromogenic/clean")
-    #Ignore the lead / when doing path.join
-    not_root_filename = clean_filename[1:]
-    mounted_clean_path = os.path.join(mounted_path,not_root_filename)
-    if not os.path.exists(mounted_clean_path):
-        return False
-    try:
-        prepare_chroot_env(mounted_path)
-        #Run this command in a prepared chroot
-        run_command(
-            ["/usr/sbin/chroot", mounted_path,
-             "/bin/bash", "-c", clean_filename])
-    except Exception, e:
-        logger.exception(e)
-        return False
-    finally:
-        remove_chroot_env(mounted_path)
-    return True
-
-
-def mount_and_clean(image_path, mount_point, created_by=None, status_hook=None, method_hook=None, **kwargs):
+def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=None, **kwargs):
     """
     Clean the local image at <image_path>
-    Mount it to <mount_point>
     """
     #Prepare the paths
     if not os.path.exists(image_path):
         logger.error("Could not find local image!")
         raise Exception("Image file not found")
 
-    if not os.path.exists(mount_point):
-        os.makedirs(mount_point)
     #FSCK the image, FIRST!
     fsck_image(image_path)
 

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -5,13 +5,13 @@ These functions are used to strip data from a VM before imaging occurs.
 
 """
 import logging, os
-from chromogenic.common import check_mounted, prepare_chroot_env,\
+from chromogenic.common import prepare_chroot_env,\
 remove_chroot_env, run_command, check_distro
 from chromogenic.common import (
     remove_files, overwrite_files,
     append_line_in_files, remove_line_in_files,
     replace_line_in_files, remove_multiline_in_files,
-    execute_chroot_commands, atmo_required_files, fsck_image, mount_image)
+    execute_chroot_commands, fsck_image, mount_image)
 import chromogenic.virt_sysprep as virt_sysprep_files
 
 logger = logging.getLogger(__name__)

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -72,7 +72,6 @@ def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=N
     logger.info("Running virt-sysprep for distro {}".format(distro))
     proc = subprocess.Popen([
         'virt-sysprep',
-        '--format', 'qcow2',
         '-a', image_path,
         '--operations', 'defaults,kerberos-data,user-account',
         '--hostname', distro,

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -72,7 +72,6 @@ def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=N
         '-a', image_path,
         '--operations', 'defaults,kerberos-data,user-account',
         '--hostname', distro,
-        '--network',
         '--commands-from-file', vs_filename
     ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out,err = proc.communicate()

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -55,6 +55,10 @@ def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=N
     output = subprocess.Popen(['virt-inspector', '-a', image_path], stdout=subprocess.PIPE).stdout.read()
     distro = output[output.find("<distro>") + 8 : output.find("</distro>")]
 
+    # Check that cloud-init is installed because virt-sysprep is currently unable to install it
+    if 'cloud-init' not in output:
+        raise Exception("cloud-init is not installed on this image so it will fail to deploy on Atmosphere")
+
     # Get filename and content based off distro
     vs_filename = "{}/virt-sysprep-{}.txt".format(os.path.dirname(image_path), distro)
     vs_content = virt_sysprep_files.commands % (getattr(virt_sysprep_files, distro))

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -53,7 +53,8 @@ def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=N
     # Figure out distro using virt-inspect
     import subprocess
     output = subprocess.Popen(['virt-inspector', '-a', image_path], stdout=subprocess.PIPE).stdout.read()
-    distro = output[output.find("<distro>") + 8 : output.find("</distro>")]
+    distro = output[output.find('<distro>') + 8 : output.find('</distro>')]
+    fstrim = 'run-command fstrim --all' if '<name>util-linux</name>' in output else ''
 
     # Check that cloud-init is installed because virt-sysprep is currently unable to install it
     if 'cloud-init' not in output:
@@ -61,7 +62,7 @@ def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=N
 
     # Get filename and content based off distro
     vs_filename = "{}/virt-sysprep-{}.txt".format(os.path.dirname(image_path), distro)
-    vs_content = virt_sysprep_files.commands % (getattr(virt_sysprep_files, distro))
+    vs_content = virt_sysprep_files.commands % (getattr(virt_sysprep_files, distro), fstrim)
 
     # Create file if it does not exist
     if not os.path.exists(vs_filename):

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -330,7 +330,8 @@ def mount_and_clean(image_path, mount_point, created_by=None, status_hook=None, 
             vs_file.write(vs_content)
 
     # Use virt-sysprep to clean image
-    run_command([
+    logger.info("Running virt-sysprep for distro {}".format(distro))
+    out, err = run_command([
         'virt-sysprep',
         '--format', 'qcow2',
         '-a', image_path,
@@ -339,3 +340,5 @@ def mount_and_clean(image_path, mount_point, created_by=None, status_hook=None, 
         '--network',
         '--commands-from-file', vs_filename
     ])
+    logger.info("virt-sysprep out: {}".format(out))
+    logger.info("virt-sysprep err: {}".format(err))

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -331,7 +331,7 @@ def mount_and_clean(image_path, mount_point, created_by=None, status_hook=None, 
 
     # Use virt-sysprep to clean image
     logger.info("Running virt-sysprep for distro {}".format(distro))
-    out, err = run_command([
+    proc = subprocess.Popen([
         'virt-sysprep',
         '--format', 'qcow2',
         '-a', image_path,
@@ -339,6 +339,10 @@ def mount_and_clean(image_path, mount_point, created_by=None, status_hook=None, 
         '--hostname', distro,
         '--network',
         '--commands-from-file', vs_filename
-    ])
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out,err = proc.communicate()
+    rc = proc.returncode
     logger.info("virt-sysprep out: {}".format(out))
-    logger.info("virt-sysprep err: {}".format(err))
+    if rc != 0:
+        logger.error("virt-sysprep exited with code {} and message: {}".format(rc, err))
+        raise Exception("virt-sysprep failed on image file {} with error: {}".format(image_path, err))

--- a/chromogenic/drivers/base.py
+++ b/chromogenic/drivers/base.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from chromogenic.common import mount_image, remove_files, fsck_image
-from chromogenic.common import run_command, atmo_required_files
+from chromogenic.common import run_command
 from chromogenic.common import copy_disk, create_empty_image
 from chromogenic.clean import mount_and_clean
 from chromogenic.common import prepare_chroot_env, remove_chroot_env
@@ -57,5 +57,3 @@ class BaseDriver():
                   download_dir=download_dir)
         #TODO: Grow filesystem via OS??
         return local_raw_path
-
-

--- a/chromogenic/drivers/eucalyptus.py
+++ b/chromogenic/drivers/eucalyptus.py
@@ -118,15 +118,11 @@ class ImageManager(BaseDriver):
         download_location = self.download_instance(**download_args)
         logger.debug("Instance downloaded to %s" % download_location)
         download_dir = download_args['download_dir']
-        mount_point = self.build_imaging_dirs(download_dir)
 
-        #Step 2. Mount and Clean image 
+        #Step 2. Mount and Clean image
         if kwargs.get('clean_image',True):
             logger.debug("Cleaning image file: %s" % download_location)
-            mount_and_clean(
-                    download_location,
-                    mount_point,
-                    **kwargs)
+            mount_and_clean(download_location, **kwargs)
 
         ##Step 3. Upload image
         upload_kwargs = self.parse_upload_args(
@@ -147,8 +143,8 @@ class ImageManager(BaseDriver):
         download_args = {}
         #REQUIRED kwargs:
         #  node_scp_info - Dictionary for accessing the node controller,
-        #  should contain: 
-        #    * hostname, 
+        #  should contain:
+        #    * hostname,
         #    * port,
         #    * username(if not root),
         #    * a private ssh_key that allows access to the box. (if necessary)
@@ -376,7 +372,7 @@ class ImageManager(BaseDriver):
                     image_name, new_image_path,
                     kernel_id, ramdisk_id,
                     download_dir, None, bucket_name,
-                    public, private_users) 
+                    public, private_users)
         finally:
             os.rename(new_image_path,image_path)
 
@@ -426,7 +422,7 @@ class ImageManager(BaseDriver):
 
         run_command(["umount", mount_point])
 
-        #Your new image is ready for upload to OpenStack 
+        #Your new image is ready for upload to OpenStack
         return (image_path, local_kernel_path, local_ramdisk_path)
 
     # __init__ privates
@@ -585,7 +581,7 @@ class ImageManager(BaseDriver):
         logger.debug("Deleted bucket %s" % bucket_name)
         return True
 
-        
+
 
     def _upload_kernel(self, image_path, bucket_name, download_dir='/tmp'):
         return self._upload_and_register(image_path, bucket_name,
@@ -600,7 +596,7 @@ class ImageManager(BaseDriver):
         bucket_name = bucket_name.lower()
         logger.debug('Bundling image %s to dir:%s'
                      % (image_path, download_dir))
-        manifest_loc = self._bundle_image(image_path, download_dir, 
+        manifest_loc = self._bundle_image(image_path, download_dir,
                                           kernel, ramdisk,
                                           ancestor_ami_ids=ancestor_ami_ids)
         logger.debug(manifest_loc)
@@ -610,7 +606,7 @@ class ImageManager(BaseDriver):
                     % new_image_id)
         return new_image_id
 
-    def scp_remote_file(self, remote_path=None, local_path=None, 
+    def scp_remote_file(self, remote_path=None, local_path=None,
                         user='root', hostname='localhost', port=22,
                         check_key=False, private_key=None):
         """
@@ -1118,5 +1114,3 @@ def _upload_parts(bucket_instance, directory, parts,
                 else:
                     logger.info(s3error_string)
                 sys.exit()
-
-

--- a/chromogenic/drivers/openstack.py
+++ b/chromogenic/drivers/openstack.py
@@ -270,7 +270,6 @@ class ImageManager(BaseDriver):
         if kwargs.get('clean_image',True):
             mount_and_clean(
                     download_location,
-                    os.path.join(download_dir, 'mount/'),
                     status_hook=getattr(self, 'hook', None),
                     method_hook=getattr(self, 'clean_hook',None),
                     **kwargs)
@@ -749,7 +748,7 @@ class ImageManager(BaseDriver):
 
     def _build_nova_creds(self, credentials):
         nova_args = credentials.copy()
-        #HACK - Nova is certified-broken-on-v3. 
+        #HACK - Nova is certified-broken-on-v3.
         nova_args['version'] = 'v2.0'
         nova_args['auth_url'] = nova_args['auth_url'].replace('v3','v2.0').replace('/tokens','')
         if credentials.get('ex_force_auth_version','3.x_password') == '2.0_password':

--- a/chromogenic/export.py
+++ b/chromogenic/export.py
@@ -37,13 +37,9 @@ def export_instance(src_managerCls, src_manager_creds, exportCls, export_kwargs)
 def begin_export(download_location, src_manager, export_kwargs):
     #Clean the image (Optional)
     download_dir = os.path.dirname(download_location)
-    mount_point = os.path.join(download_dir, 'mount_point/')
-    if not os.path.exists(mount_point):
-        os.makedirs(mount_point)
     if export_kwargs.get('clean_image',True):
         mount_and_clean(
                 download_location,
-                mount_point,
                 status_hook=getattr(src_manager, 'hook', None),
                 method_hook=getattr(src_manager, 'clean_hook', None),
                 **export_kwargs)

--- a/chromogenic/migrate.py
+++ b/chromogenic/migrate.py
@@ -22,13 +22,9 @@ def migrate_instance(src_managerCls, src_manager_creds, migrationCls, migration_
     imaging_args['download_location'] = download_location
     #Clean it
     download_dir = os.path.dirname(download_location)
-    mount_point = os.path.join(download_dir, 'mount_point/')
-    if not os.path.exists(mount_point):
-        os.makedirs(mount_point)
     if imaging_args.get('clean_image',True):
         mount_and_clean(
                 download_location,
-                mount_point,
                 status_hook=getattr(src_manager, 'hook', None),
                 method_hook=getattr(src_manager, 'clean_hook', None),
                 **imaging_args)
@@ -48,14 +44,10 @@ def migrate_image(src_managerCls, src_manager_creds, migrationCls, migration_cre
     download_location = src_manager.download_image(**download_kwargs)
     #Clean it
     download_dir = os.path.dirname(download_location)
-    mount_point = os.path.join(download_dir, 'mount_point/')
-    if not os.path.exists(mount_point):
-        os.makedirs(mount_point)
     imaging_args['download_location'] = download_location
     if imaging_args.get('clean_image',True):
         mount_and_clean(
                 download_location,
-                mount_point,
                 status_hook=getattr(src_manager, 'hook', None),
                 method_hook=getattr(src_manager, 'clean_hook', None),
                 **imaging_args)
@@ -73,14 +65,10 @@ def start_migration(migrationCls, migration_creds, download_location, **imaging_
     dest_manager = migrationCls(**migration_creds)
     dest_manager.hook = imaging_args.get('machine_request', None)
     download_dir = os.path.dirname(download_location)
-    mount_point = os.path.join(download_dir, 'mount_point/')
-    if not os.path.exists(mount_point):
-        os.makedirs(mount_point)
     #2. clean using dest manager
     if imaging_args.get('clean_image',True):
         mount_and_clean(
                 download_location,
-                mount_point,
                 status_hook=getattr(dest_manager, 'hook', None),
                 method_hook=getattr(dest_manager, 'clean_hook', None),
                 **imaging_args)

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -1,7 +1,14 @@
-commands = r"""edit /etc/group:s/^users:x:100:.*/users:x:100:/
+commands = r"""touch /etc/group
+edit /etc/group:s/^users:x:100:.*/users:x:100:/
 edit /etc/group:s/^.+:x:1[0-9][0-9][0-9]:\n//
+
+touch /etc/ssh/sshd_config
 edit /etc/ssh/sshd_config:s/^AllowGroups users root.*\n//
+
+touch /etc/rc.local
 edit /etc/rc.local:s/.*vncserver$//
+
+touch /etc/fstab
 edit /etc/fstab:s/\/dev\/sda[2-9].*\n//
 edit /etc/fstab:s/\/dev\/sda1[0-9].*\n//
 edit /etc/fstab:s/\/dev\/vd[b-z].*\n//

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -58,6 +58,7 @@ touch /lib/udev/rules.d/75-persistent-net-generator.rules
 truncate /lib/udev/rules.d/75-persistent-net-generator.rules
 
 root-password password:atmosphere
+%s
 """
 
 ubuntu = ""

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -1,4 +1,5 @@
 commands = r"""edit /etc/group:s/^users:x:100:.*/users:x:100:/
+edit /etc/group:s/^.+:x:1[0-9][0-9][0-9]:\n//
 edit /etc/ssh/sshd_config:s/^AllowGroups users root.*\n//
 edit /etc/rc.local:s/.*vncserver$//
 edit /etc/fstab:s/\/dev\/sda[2-9].*\n//

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -51,9 +51,6 @@ touch /lib/udev/rules.d/75-persistent-net-generator.rules
 truncate /lib/udev/rules.d/75-persistent-net-generator.rules
 
 root-password password:atmosphere
-
-install cloud-init,cloud-utils
-uninstall avahi-daemon,fail2ban
 """
 
 ubuntu = ""

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -1,0 +1,74 @@
+commands = r"""edit /etc/group:s/^users:x:100:.*/users:x:100:/
+edit /etc/ssh/sshd_config:s/^AllowGroups users root.*\n//
+edit /etc/rc.local:s/.*vncserver$//
+edit /etc/fstab:s/\/dev\/sda[2-9].*\n//
+edit /etc/fstab:s/\/dev\/sda1[0-9].*\n//
+edit /etc/fstab:s/\/dev\/vd[b-z].*\n//
+
+%s
+# Cloud config
+mkdir /etc/cloud
+touch /etc/cloud/cloud.cfg
+edit /etc/cloud/cloud.cfg:s/^users:/#users:/
+edit /etc/cloud/cloud.cfg:s/^[ ]* - default/#  - default/
+edit /etc/cloud/cloud.cfg:s/^disable_root: true/disable_root: false/
+edit /etc/cloud/cloud.cfg:s/^disable_root: 1/disable_root: 0/
+edit /etc/cloud/cloud.cfg:s/^ssh_deletekeys:.*1/ssh_deletekeys: 0/
+edit /etc/cloud/cloud.cfg:s/^ssh_deletekeys:.*true/ssh_deletekeys: false/
+
+# Multi-line deletes
+edit /etc/sudoers:BEGIN{undef $/;} s/\n\#\# Atmosphere System.*\#\# End Atmosphere System\n//smg
+edit /etc/sudoers:BEGIN{undef $/;} s/\n\# Begin Nagios.*\# End Nagios\n//smg
+edit /etc/sudoers:BEGIN{undef $/;} s/\n\# Begin Sensu.*\# End Sensu\n//smg
+edit /etc/sudoers:BEGIN{undef $/;} s/\n\#includedir \/etc\/sudoers\.d.*\n/\#includedir \/etc\/sudoers\.d\n/smg
+
+edit /etc/ssh/sshd_config:BEGIN{undef $/;} s/\#\# Atmosphere System.*\#\# End Atmosphere System\n//smg
+edit /etc/skel/.bashrc:BEGIN{undef $/;} s/\#\# Atmosphere System.*\#\# End Atmosphere System\n//smg
+
+# CyVerse/Atmo stuff
+delete /var/log/atmo
+touch /etc/rc.local.atmo
+delete /etc/rc.local.atmo
+delete /opt/cyverse
+touch /usr/sbin/atmo_boot.py
+delete /usr/sbin/atmo_boot.py
+
+# Delete some directory contents
+mkdir /mnt
+delete /mnt
+mkdir /mnt
+delete /tmp
+mkdir /tmp
+delete /proc
+mkdir /proc
+
+# Log files
+truncate-recursive /var/log
+touch /etc/udev/rules.d/70-persistent-net.rules
+truncate /etc/udev/rules.d/70-persistent-net.rules
+touch /lib/udev/rules.d/75-persistent-net-generator.rules
+truncate /lib/udev/rules.d/75-persistent-net-generator.rules
+
+root-password password:atmosphere
+
+install cloud-init,cloud-utils
+uninstall avahi-daemon,fail2ban
+"""
+
+ubuntu = ""
+
+centos = """# Sysconfig stuff
+mkdir /etc/sysconfig
+mkdir /etc/sysconfig/network-scripts
+touch /etc/sysconfig/network-scripts/ifcfg-eth0
+edit /etc/sysconfig/network-scripts/ifcfg-eth0:s/^HWADDR=*\\n//
+edit /etc/sysconfig/network-scripts/ifcfg-eth0:s/^MACADDR=*\\n//
+
+# SELinux stuff
+mkdir /etc/syslinux
+touch /etc/syslinux/selinux
+edit /etc/syslinux/selinux:s/SELINUX=.*/SELINUX=disabled/
+mkdir /etc/selinux
+touch /etc/selinux/config
+edit /etc/selinux/config:s/SELINUX=.*/SELINUX=disabled/
+"""


### PR DESCRIPTION
## Description
- Add new file with two variables for virt-sysprep commands to use
depending on distro
- In clean.py, instead of running all the helper functions to edit files
in the image, determine the distro, create commands file, and run
virt-sysprep

This requires a few other PRs to Atmosphere and Clank because the version of `virt-sysprep` that I need is only available on Ubuntu 18.04. 

~Also, there are still some old, now unused, parts of Chromogenic that I need to remove.~

**NOTE**: In order to use Atmosphere in a production or production-like environment with imaging enabled, these changes are needed

## Checklist before merging Pull Requests
- [ ] New test(s) included to reproduce the bug/verify the feature
- [x] Add an entry in the changelog
- [ ] Documentation created/updated (include links)
- [ ] If creating/modifying DB models which will contain secrets or sensitive information, PR to [clank](https://github.com/cyverse/clank) updating sanitation queries in `roles/sanitary-sql-access/templates/sanitize-dump.sh.j2`
- [ ] Reviewed and approved by at least one other contributor.