### PR TITLE
Fix bug when checking for cloud-init install -- version 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - <in case of vulnerabilities>
 -->
 
-## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.5.0...HEAD) - YYYY-MM-DD
+## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.5.1...HEAD) - YYYY-MM-DD
+
+## [0.5.1](https://github.com/cyverse/chromogenic/compare/0.5.0...0.5.1) - 2019-06-07
+### Fixed
+  - Check for '<name>cloud-init</name>' to make sure 'cloud-init' is installed
+    ([#15](https://github.com/cyverse/chromogenic/pull/15))
 
 ## [0.5.0](https://github.com/cyverse/chromogenic/compare/0.4.20...0.5.0) - 2019-06-03
   - Replace chroot and mount with virt-sysprep for preparing and cleaning images

--- a/chromogenic/clean.py
+++ b/chromogenic/clean.py
@@ -57,7 +57,7 @@ def mount_and_clean(image_path, created_by=None, status_hook=None, method_hook=N
     fstrim = 'run-command fstrim --all' if '<name>util-linux</name>' in output else ''
 
     # Check that cloud-init is installed because virt-sysprep is currently unable to install it
-    if 'cloud-init' not in output:
+    if '<name>cloud-init</name>' not in output:
         raise Exception("cloud-init is not installed on this image so it will fail to deploy on Atmosphere")
 
     # Get filename and content based off distro


### PR DESCRIPTION
## Description

When checking that cloud-init is installed, a false positive would occur from packages with `cloud-init` in the name. This fix make the check more specific.

## Checklist before merging Pull Requests
- [x] Add an entry in the changelog
- [ ] Reviewed and approved by at least one other contributor.
