### PR TITLE
Remove lines to edit rc.local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 -->
 
 ## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.5.1...HEAD) - YYYY-MM-DD
+### Fixed
+  - Remove lines to modify /etc/rc.local because it often fails
+    ([#19](https://github.com/cyverse/chromogenic/pull/19))
 
 ## [0.5.1](https://github.com/cyverse/chromogenic/compare/0.5.0...0.5.1) - 2019-06-07
 ### Fixed

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -5,9 +5,6 @@ edit /etc/group:s/^.+:x:1[0-9][0-9][0-9]:\n//
 touch /etc/ssh/sshd_config
 edit /etc/ssh/sshd_config:s/^AllowGroups users root.*\n//
 
-touch /etc/rc.local
-edit /etc/rc.local:s/.*vncserver$//
-
 touch /etc/fstab
 edit /etc/fstab:s/\/dev\/sda[2-9].*\n//
 edit /etc/fstab:s/\/dev\/sda1[0-9].*\n//


### PR DESCRIPTION
## Description

On some CentOS instances, /etc/rc.local is a link and cannot be touched.
Also, the change this makes is not necessary in the imaging process
