### PR TITLE
Release 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.5.2...HEAD) - YYYY-MM-DD
 
-## [0.5.2](https://github.com/cyverse/chromogenic/compare/0.5.1...0.5.2) - 2019-09-27
+## [0.5.3](https://github.com/cyverse/chromogenic/compare/0.5.1...0.5.2) - 2019-09-27
 ### Fixed
   - Remove lines to modify /etc/rc.local because it often fails
     ([#19](https://github.com/cyverse/chromogenic/pull/19))

--- a/chromogenic/version.py
+++ b/chromogenic/version.py
@@ -5,7 +5,7 @@ Current logger version.
 from subprocess import Popen, PIPE
 from os.path import abspath, dirname
 
-VERSION = (0, 5, 2, 'dev', 0)
+VERSION = (0, 5, 3, 'dev', 0)
 
 git_match = "(?P<git_flag>git://)\S*#egg="\
             "(?P<egg>[a-zA-Z0-9-]*[a-zA-Z])"\


### PR DESCRIPTION
## Description

I am creating this release because PyPI is not letting me upload `0.5.2`:
```
Uploading chromogenic-0.5.2-py2-none-any.whl
100%|████████████████████████████████████████████████████████████████████████████████████| 57.0k/57.0k [00:01<00:00, 39.5kB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Client Error: This filename has already been used, use a different version. See https://pypi.org/help/#file-name-reuse for url: https://upload.pypi.org/legacy/
```