### PR TITLE
Do not delete /tmp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   - <in case of vulnerabilities>
 -->
 
-## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.5.2...HEAD) - YYYY-MM-DD
+## [Unreleased](https://github.com/cyverse/chromogenic/compare/0.5.3...HEAD) - YYYY-MM-DD
+### Fixed
+  - Removed lines to delete/reset `/tmp` since it is cleaned by default
+    ([#22](https://github.com/cyverse/chromogenic/pull/22))
 
-## [0.5.3](https://github.com/cyverse/chromogenic/compare/0.5.1...0.5.2) - 2019-09-27
+## [0.5.3](https://github.com/cyverse/chromogenic/compare/0.5.1...0.5.3) - 2019-09-27
 ### Fixed
   - Remove lines to modify /etc/rc.local because it often fails
     ([#19](https://github.com/cyverse/chromogenic/pull/19))

--- a/chromogenic/virt_sysprep.py
+++ b/chromogenic/virt_sysprep.py
@@ -42,8 +42,6 @@ delete /usr/sbin/atmo_boot.py
 mkdir /mnt
 delete /mnt
 mkdir /mnt
-delete /tmp
-mkdir /tmp
 delete /proc
 mkdir /proc
 


### PR DESCRIPTION
## Description

Deleting and re-creating `/tmp` in order to clean it causes incorrect permissions on the directory.

virt-sysprep will clean `/tmp` by default so this is not necessary.
